### PR TITLE
Fix sendcreategroupchat

### DIFF
--- a/WhatsAppApi/WhatsApp.cs
+++ b/WhatsAppApi/WhatsApp.cs
@@ -838,7 +838,7 @@ namespace WhatsAppApi
 
         public void SendGetGroups(string id, string type)
         {
-            var child = new ProtocolTreeNode("list", new[] { new KeyValue("type", type) });
+            var child = new ProtocolTreeNode(type, null);
             var node = new ProtocolTreeNode("iq", new[] { new KeyValue("id", id), new KeyValue("type", "get"), new KeyValue("xmlns", "w:g2"), new KeyValue("to", "g.us") }, child);
             this.SendNode(node);
         }

--- a/WhatsAppApi/WhatsApp.cs
+++ b/WhatsAppApi/WhatsApp.cs
@@ -447,8 +447,8 @@ namespace WhatsAppApi
         {
             string id = TicketCounter.MakeId();
             IEnumerable<ProtocolTreeNode> participant = from jid in participants select new ProtocolTreeNode("participant", new[] { new KeyValue("jid", GetJID(jid)) });
-	    var child = new ProtocolTreeNode("create", new[] { new KeyValue("subject", subject) }, new ProtocolTreeNode[] { (ProtocolTreeNode) participant });
-	    var node = new ProtocolTreeNode("iq", new[] { new KeyValue("id", id), new KeyValue("type", "set"), new KeyValue("xmlns", "w:g2"), new KeyValue("to", "g.us") }, new ProtocolTreeNode[] { child });
+            var child = new ProtocolTreeNode("create", new[] { new KeyValue("subject", subject) }, participant.ToList<ProtocolTreeNode>());
+            var node = new ProtocolTreeNode("iq", new[] { new KeyValue("id", id), new KeyValue("type", "set"), new KeyValue("xmlns", "w:g2"), new KeyValue("to", "g.us") }, new ProtocolTreeNode[] { child });
             this.SendNode(node);
         }
 


### PR DESCRIPTION
fix the error 
Unable to cast object of type 'WhereSelectArrayIterator`2[System.String,WhatsAppApi.Helper.ProtocolTreeNode]' to type 'WhatsAppApi.Helper.ProtocolTreeNode'.
